### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 VimPlugins
 =========
 
-###Quick Installation  
+### Quick Installation  
 
 	$git clone https://github.com/chenfjm/VimPlugins.git
 	$mv VimPlugins ~/.vim
@@ -11,13 +11,13 @@ VimPlugins
 	$git submodule update   
 	$cp .vimrc ~
 
-###PluginInstall  
+### PluginInstall  
 
 	$:PluginInstall(in vim)
 	$cd ~/.vim/bundle/YouCompleteMe
 	$./install.sh (--clang-completer)
 
-###Requirements  
+### Requirements  
 
 - Mac OS
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
